### PR TITLE
Edit cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,15 @@ Naming/FileName:
   Enabled: true
   Exclude:
     - "rubocop-wundertax.gemspec"
+
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional
+
+Metrics/BlockLength:
+  Exclude:
+   - !ruby/regexp /_spec\.rb$/
+   - !ruby/regexp /\.gemspec$/
+
+Layout/IndentHeredoc:
+  Exclude:
+  - !ruby/regexp /_generator\.rb$/

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This repository provides recommended RuboCop configuration for use on Wundertax 
 **Gemfile**
 
 ``` ruby
-gem "rubocop-wundertax"
+gem "rubocop-wundertax", git: 'https://github.com/wundertax/rubocop-wundertax.git'
 ```
 
-**.rubocop.yml**
+Create the **.rubocop.yml** file at the root of the repos
 
 ``` yaml
 inherit_gem:
   rubocop-wundertax:
-    - config/default.yml
+    - .rubocop.yml
 ```

--- a/config/default.yml
+++ b/config/default.yml
@@ -740,7 +740,7 @@ Style/EvenOdd:
 Layout/InitialIndentation:
   Enabled: true
 
-Style/FlipFlop:
+Lint/FlipFlop:
   Enabled: true
 
 Style/IfInsideElse:


### PR DESCRIPTION
The PR aims to edit a few cops

-   Edit `Naming/MemoizedInstanceVariableName` to allow [EnforcedStyleForLeadingUnderscores](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/MemoizedInstanceVariableName)
-   Exclude `Metrics/BlockLength` from spec files and gemspecs
-   Exclude  `Layout/IndentHeredoc` from generators files to avoid broken indentation in result files
-   Edit README with correct rubocop file instrunctions
-   Update namespace for broken cop `FlipFlop`