### PR TITLE
remove the cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,7 @@
 inherit_from: ./config/default.yml
 
 Naming/FileName:
-  Enabled: true
-  Exclude:
-    - "rubocop-wundertax.gemspec"
+  Enabled: false
 
 Naming/MemoizedInstanceVariableName:
   EnforcedStyleForLeadingUnderscores: optional


### PR DESCRIPTION
I propose to disable the cop on the snake name file name convention because it crashes with the one we have of naming the repos with `-` instead of with `_`.
The spreads out in rubocop offenses when naming the files accorgin with the repo name.