### PR TITLE
disable metric block length cop on support shared_examples dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ Create the **.rubocop.yml** file at the root of the repos
 ``` yaml
 inherit_gem:
   rubocop-wundertax:
-    - .rubocop.yml
+    - config/default.yml
 ```

--- a/config/default.yml
+++ b/config/default.yml
@@ -1177,6 +1177,7 @@ Naming/MemoizedInstanceVariableName:
 Metrics/BlockLength:
   Exclude:
    - !ruby/regexp /_spec\.rb$/
+   - !ruby/regexp /spec\/support\/shared_examples/
    - !ruby/regexp /\.gemspec$/
 
 Style/TrailingCommaInArrayLiteral:


### PR DESCRIPTION
Disable Metrics/BlockLength cop on shared_example files